### PR TITLE
Add keywords for gitGraph syntax

### DIFF
--- a/syntax/mermaid.vim
+++ b/syntax/mermaid.vim
@@ -1,6 +1,6 @@
 setlocal iskeyword+=-
 
-syntax keyword mermaidDiagramType classDiagram classDiagram-v2 erDiagram gantt graph flowchart pie sequenceDiagram stateDiagram stateDiagram-v2
+syntax keyword mermaidDiagramType classDiagram classDiagram-v2 erDiagram gantt graph flowchart pie sequenceDiagram stateDiagram stateDiagram-v2 gitGraph
 syntax match mermaidOperator /\v(-|\<|\>|\+|\||\=)/
 syntax match mermaidComment /\v^(\s?)+\%\%.*$/
 syntax region mermaidString start=/"/ end=/"/ skip=/\\"/
@@ -31,6 +31,9 @@ syntax match mermaidClassFunction /\v\w+\(((\w+|\s+|\~)?,?)+\)/ contains=ALLBUT,
 syntax match mermaidStateFinalKeyword /\[\*\]/
 syntax match mermaidStateKeyword /\v(\s+as[^a-z]|^\s+state)/
 
+syntax match mermaidGitOption /\v^(options|end)/
+syntax match mermaidGitCommands /\v^(commit|branch|merge|reset|checkout)/
+
 " TODO highlight gantt keywords
 
 " TODO improve er operators
@@ -59,3 +62,6 @@ highlight link mermaidStateFinalKeyword Keyword
 highlight link mermaidStateKeyword Keyword
 
 highlight link mermaidErOperator Operator
+
+highlight link mermaidGitOption Keyword
+highlight link mermaidGitCommands Keyword


### PR DESCRIPTION
I was interested to know that [Mermaid syntax is now supported on GitHub](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) and found your great plugin.

This P-R adds the Git graph syntax I want to use.
![image](https://user-images.githubusercontent.com/221802/154075488-8f64cf7b-eafd-4806-ba8c-e1250b219193.png)

If there is anything else I can do to help, I will try. Thank you.